### PR TITLE
Add PORTABLE_WHEEL option to CMakeLists.txt

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -9,6 +9,8 @@ on:
   release:
     types:
       - published
+env:
+  SKBUILD_CONFIGURE_OPTIONS: -DPORTABLE_WHEEL=ON
 
 jobs:
   build_sdist:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,13 @@ if(SKBUILD)
   list(APPEND CMAKE_PREFIX_PATH "${_tmp_dir}")
 endif()
 
+# Enable this option if you want to build wheels for PyPI
+if(PORTABLE_WHEEL)
+  set(NGT_MARCH_NATIVE_DISABLED, ON)
+  set(NGT_AVX_DISABLED ON)
+else()
+  add_compile_options(-Ofast -march=native -DNDEBUG)
+endif()
 
 add_subdirectory(extern/NGT EXCLUDE_FROM_ALL)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ if(PORTABLE_WHEEL)
   set(NGT_MARCH_NATIVE_DISABLED, ON)
   set(NGT_AVX_DISABLED ON)
 else()
-  message(STATUS "Building ngtpy for local installation")
+  message(STATUS "Building optimized ngtpy for local installation")
   # Use same compiler options as NGT
   add_compile_options(-Ofast -march=native -DNDEBUG)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,13 @@ if(SKBUILD)
   list(APPEND CMAKE_PREFIX_PATH "${_tmp_dir}")
 endif()
 
-# Enable this option if you want to build wheels for PyPI
 if(PORTABLE_WHEEL)
+  message(STATUS "Building ngtpy for portable wheels")
   set(NGT_MARCH_NATIVE_DISABLED, ON)
   set(NGT_AVX_DISABLED ON)
 else()
+  message(STATUS "Building ngtpy for local installation")
+  # Use same compiler options as NGT
   add_compile_options(-Ofast -march=native -DNDEBUG)
 endif()
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     cmake_install_dir="src/ngtpy",
-    cmake_args=["-DNGT_MARCH_NATIVE_DISABLED=ON", "-DNGT_AVX_DISABLED=ON"],
     extras_require={"test": ["pytest"]},
     python_requires=">=3.6",
     install_requires=["numpy"],


### PR DESCRIPTION
Fix #4. Add `PORTABLE_WHEEL` option to CMakeLists.txt.

* `python -m build`: build optimized ngtpy for local installation
* `SKBUILD_CONFIGURE_OPTIONS="-DPORTABLE_WHEEL=ON" python -m build`: build ngtpy for portable wheels

<details>
<summary>log</summary>

```
$ python -m build

Configuring Project
  Working directory:
    /private/var/folders/1t/67zx481n1l1ckxzm9fzrxfy40000gn/T/build-via-sdist-pzzl3sn5/ngtpy-0.1.1/_skbuild/macosx-12.0-x86_64-3.9/cmake-build
  Command:
    cmake /private/var/folders/1t/67zx481n1l1ckxzm9fzrxfy40000gn/T/build-via-sdist-pzzl3sn5/ngtpy-0.1.1 -G Ninja -DCMAKE_INSTALL_PREFIX:PATH=/private/var/folders/1t/67zx481n1l1ckxzm9fzrxfy40000gn/T/build-via-sdist-pzzl3sn5/ngtpy-0.1.1/_skbuild/macosx-12.0-x86_64-3.9/cmake-install/src/ngtpy -DPYTHON_EXECUTABLE:FILEPATH=/private/var/folders/1t/67zx481n1l1ckxzm9fzrxfy40000gn/T/build-env-5dg2hriy/bin/python -DPYTHON_VERSION_STRING:STRING=3.9.10 -DPYTHON_INCLUDE_DIR:PATH=/usr/local/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -DPYTHON_LIBRARY:FILEPATH=/usr/local/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/lib/libpython3.9.dylib -DSKBUILD:INTERNAL=TRUE -DCMAKE_MODULE_PATH:PATH=/private/var/folders/1t/67zx481n1l1ckxzm9fzrxfy40000gn/T/build-env-5dg2hriy/lib/python3.9/site-packages/skbuild/resources/cmake -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=12.0 -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64

-- The C compiler identification is AppleClang 13.1.6.13160021
-- The CXX compiler identification is AppleClang 13.1.6.13160021
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
'/private/var/folders/1t/67zx481n1l1ckxzm9fzrxfy40000gn/T/build-env-5dg2hriy/bin/python' '-c' 'import pybind11; print(pybind11.get_cmake_dir())'
-- Building ngtpy for local installation
-- VERSION: 1.14.3
-- CMAKE_BUILD_TYPE: Release
-- CMAKE_BUILD_TYPE_LOWER: release
-- Found OpenMP_C: -Xclang -fopenmp (found version "5.0")
-- Found OpenMP_CXX: -Xclang -fopenmp (found version "5.0")
-- Found OpenMP: TRUE (found version "5.0")
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Found PythonInterp: /private/var/folders/1t/67zx481n1l1ckxzm9fzrxfy40000gn/T/build-env-5dg2hriy/bin/python (found version "3.9.10")
-- Found PythonLibs: /usr/local/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/lib/libpython3.9.dylib
-- Performing Test HAS_FLTO
-- Performing Test HAS_FLTO - Success
-- Performing Test HAS_FLTO_THIN
-- Performing Test HAS_FLTO_THIN - Success
-- Found pybind11: /private/var/folders/1t/67zx481n1l1ckxzm9fzrxfy40000gn/T/build-env-5dg2hriy/lib/python3.9/site-packages/pybind11/include (found version "2.9.2")
-- Configuring done
-- Generating done
-- Build files have been written to: /private/var/folders/1t/67zx481n1l1ckxzm9fzrxfy40000gn/T/build-via-sdist-pzzl3sn5/ngtpy-0.1.1/_skbuild/macosx-12.0-x86_64-3.9/cmake-build

$ SKBUILD_CONFIGURE_OPTIONS="-DPORTABLE_WHEEL=ON" pyproject-build

Configuring Project
  Working directory:
    /private/var/folders/1t/67zx481n1l1ckxzm9fzrxfy40000gn/T/build-via-sdist-gdr0oa_n/ngtpy-0.1.1/_skbuild/macosx-12.0-x86_64-3.9/cmake-build
  Command:
    cmake /private/var/folders/1t/67zx481n1l1ckxzm9fzrxfy40000gn/T/build-via-sdist-gdr0oa_n/ngtpy-0.1.1 -G Ninja -DCMAKE_INSTALL_PREFIX:PATH=/private/var/folders/1t/67zx481n1l1ckxzm9fzrxfy40000gn/T/build-via-sdist-gdr0oa_n/ngtpy-0.1.1/_skbuild/macosx-12.0-x86_64-3.9/cmake-install/src/ngtpy -DPYTHON_EXECUTABLE:FILEPATH=/private/var/folders/1t/67zx481n1l1ckxzm9fzrxfy40000gn/T/build-env-bfo9b1hs/bin/python -DPYTHON_VERSION_STRING:STRING=3.9.10 -DPYTHON_INCLUDE_DIR:PATH=/usr/local/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -DPYTHON_LIBRARY:FILEPATH=/usr/local/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/lib/libpython3.9.dylib -DSKBUILD:INTERNAL=TRUE -DCMAKE_MODULE_PATH:PATH=/private/var/folders/1t/67zx481n1l1ckxzm9fzrxfy40000gn/T/build-env-bfo9b1hs/lib/python3.9/site-packages/skbuild/resources/cmake -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=12.0 -DCMAKE_OSX_ARCHITECTURES:STRING=x86_64 -DPORTABLE_WHEEL=ON

-- The C compiler identification is AppleClang 13.1.6.13160021
-- The CXX compiler identification is AppleClang 13.1.6.13160021
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Library/Developer/CommandLineTools/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
'/private/var/folders/1t/67zx481n1l1ckxzm9fzrxfy40000gn/T/build-env-bfo9b1hs/bin/python' '-c' 'import pybind11; print(pybind11.get_cmake_dir())'
-- Building ngtpy for portable wheels
-- VERSION: 1.14.3
-- CMAKE_BUILD_TYPE: Release
-- CMAKE_BUILD_TYPE_LOWER: release
-- AVX will not be used to compute distances.
-- Found OpenMP_C: -Xclang -fopenmp (found version "5.0")
-- Found OpenMP_CXX: -Xclang -fopenmp (found version "5.0")
-- Found OpenMP: TRUE (found version "5.0")
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Found PythonInterp: /private/var/folders/1t/67zx481n1l1ckxzm9fzrxfy40000gn/T/build-env-bfo9b1hs/bin/python (found version "3.9.10")
-- Found PythonLibs: /usr/local/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/lib/libpython3.9.dylib
-- Performing Test HAS_FLTO
-- Performing Test HAS_FLTO - Success
-- Performing Test HAS_FLTO_THIN
-- Performing Test HAS_FLTO_THIN - Success
-- Found pybind11: /private/var/folders/1t/67zx481n1l1ckxzm9fzrxfy40000gn/T/build-env-bfo9b1hs/lib/python3.9/site-packages/pybind11/include (found version "2.9.2")
-- Configuring done
-- Generating done
-- Build files have been written to: /private/var/folders/1t/67zx481n1l1ckxzm9fzrxfy40000gn/T/build-via-sdist-gdr0oa_n/ngtpy-0.1.1/_skbuild/macosx-12.0-x86_64-3.9/cmake-build
```

</details>